### PR TITLE
Allow extension config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Sample comment:
     ```
 
     ## Button types
-    
+
     You can also show examples in markdown tables as follows:
 
     Button                                                                  | Class
@@ -79,8 +79,9 @@ For documentation, see [how to use colour palettes](https://github.com/blongden/
 * support for JavaScript content
 * [referencing other components](https://github.com/trulia/hologram#referencing-other-components)
 
-### Features not in scope
-* support for colour values in palettes that require compilation, such as `darken($brand-primary, 10%)` and nested colour variables
+### Unsupported features
+* colour values in palettes that require compilation, such as `darken($brand-primary, 10%)` and nested colour variables
+* Ruby-specific: `.erb` as a source and 'slim' for templates
 
 ## Getting help
 

--- a/libs/holograph.js
+++ b/libs/holograph.js
@@ -96,7 +96,6 @@ function preparePageLinks(current, pages) {
         title: 'Home',
         selected: current === 'index' ? 'selected' : ''
     }];
-    
     var category;
 
     for (category in pages) {
@@ -110,6 +109,13 @@ function preparePageLinks(current, pages) {
     }
 
     return links;
+}
+
+function getExtensions(config) {
+    var defaultExtensions = ['css', 'scss', 'less', 'sass', 'styl', 'js', 'md', 'markdown'];
+    var extensions =  config.custom_extensions || defaultExtensions;
+
+    return extensions.join('|');
 }
 
 function processFiles(results, config) {
@@ -167,9 +173,11 @@ function maybeThrowError(err) {
 }
 
 function holograph(config) {
+    var filter = new RegExp('\\.(' + getExtensions(config) + ')$');
+
     setupBuildDir(config.destination, config.documentation_assets, function() {
         copyDependencies(config.destination, config.dependencies, function() {
-            search.recursiveSearch(/.scss$/, config.source, maybeThrowError, function(results) {
+            search.recursiveSearch(filter, config.source, maybeThrowError, function(results) {
                 processFiles(results, config);
             });
         });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "meta-marked": "^0.4.1",
     "mustache": "^2.2.1",
     "ncp": "^2.0.0",
-    "recursive-search": "^1.0.1",
+    "dive": "^0.5.0",
     "rimraf": "^2.5.2"
   },
   "main": "./libs/holograph.js",


### PR DESCRIPTION
Caolan is appalled by how we form the regex for `recursive-search`. Might be good to find another module that allows passing in of a function as our query.

To resolve issue #5 .